### PR TITLE
Add a procedure "runtime" for Exercise 1.22

### DIFF
--- a/compat/sicp.scm
+++ b/compat/sicp.scm
@@ -3,12 +3,17 @@
 ;;;
 
 (define-module compat.sicp
-  (export nil false get put get-coercion put-coercion
+  (export nil runtime false get put get-coercion put-coercion
           cons-stream))
 
 ;; This doesn't make nil as a boolean false, but in SICP nil is exclusively
 ;; used to denote an empty list, so it's ok.
 (define nil '())
+
+;; Exercise 1.22
+(define (runtime)
+  (round->exact (* (expt 10 6)
+		   (time->seconds (current-time)))))
 
 ;; Section 2.3
 ;; Boolean false


### PR DESCRIPTION
In SICP, this procedure is described as:

  returns an integer that specifies the amount of time
  the system has been running (measured, for example,
  in microseconds).

Our procedure returns microseconds from Unix Epoch but it's sufficient
for the exercise.
