### PR TITLE
Add a definition to (remainder)

### DIFF
--- a/compat/sicp.scm
+++ b/compat/sicp.scm
@@ -21,6 +21,7 @@
 (define true #t)
 (define (random n)
   (random-integer n))
+(define (remainder a b) (mod a b))
 
 ;; Section 2.3
 ;; Boolean false


### PR DESCRIPTION
Some exercised in section 1.2 use the procedure remainder which in biwa scheme should be the same as the mod procedure.